### PR TITLE
NSLocationAlwaysAndWhenInUseUsageDescription を追加

### DIFF
--- a/iosapp/06-earthquake/Info.plist
+++ b/iosapp/06-earthquake/Info.plist
@@ -22,6 +22,8 @@
 	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>近くの避難所を表示します</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>近くの避難所を表示します</string>
 	<key>UIBackgroundModes</key>


### PR DESCRIPTION
ios 13 でも許可ダイアログが出るようにしました。

![image](https://user-images.githubusercontent.com/893643/65258648-2f53ff00-db3e-11e9-9a81-43fd88575133.png)
