### PR TITLE
動作を改善

### DIFF
--- a/iosapp/06-earthquake/Assets.xcassets/camera.imageset/Contents.json
+++ b/iosapp/06-earthquake/Assets.xcassets/camera.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/iosapp/06-earthquake/Base.lproj/Main.storyboard
+++ b/iosapp/06-earthquake/Base.lproj/Main.storyboard
@@ -463,6 +463,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="camera" translatesAutoresizingMaskIntoConstraints="NO" id="fQA-Uk-65T">
+                                <rect key="frame" x="174.5" y="146.5" width="26" height="20"/>
+                                <color key="tintColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </imageView>
                             <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sj8-OS-TaU">
                                 <rect key="frame" x="16" y="60" width="343" height="193"/>
                                 <constraints>
@@ -493,8 +497,10 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="zjF-xQ-a0h" firstAttribute="trailing" secondItem="sj8-OS-TaU" secondAttribute="trailing" constant="16" id="3ei-ka-io4"/>
+                            <constraint firstItem="fQA-Uk-65T" firstAttribute="centerY" secondItem="sj8-OS-TaU" secondAttribute="centerY" id="8xY-GM-3h5"/>
                             <constraint firstItem="zjF-xQ-a0h" firstAttribute="trailing" secondItem="Q0e-7q-enU" secondAttribute="trailing" constant="16" id="HaD-Gh-6c8"/>
                             <constraint firstItem="Q0e-7q-enU" firstAttribute="leading" secondItem="zjF-xQ-a0h" secondAttribute="leading" constant="16" id="Ocj-Tf-d5W"/>
+                            <constraint firstItem="fQA-Uk-65T" firstAttribute="centerX" secondItem="sj8-OS-TaU" secondAttribute="centerX" id="XvA-rI-Eup"/>
                             <constraint firstItem="sj8-OS-TaU" firstAttribute="top" secondItem="zjF-xQ-a0h" secondAttribute="top" constant="16" id="Ymv-R0-h0k"/>
                             <constraint firstItem="sj8-OS-TaU" firstAttribute="leading" secondItem="zjF-xQ-a0h" secondAttribute="leading" constant="16" id="dXF-7Z-gXg"/>
                             <constraint firstItem="Q0e-7q-enU" firstAttribute="top" secondItem="sj8-OS-TaU" secondAttribute="bottom" constant="16" id="vL3-k0-Li7"/>

--- a/iosapp/06-earthquake/Controller/MyPageViewController.swift
+++ b/iosapp/06-earthquake/Controller/MyPageViewController.swift
@@ -26,6 +26,10 @@ class MyPageViewController: UIViewController {
         // Do any additional setup after loading the view.
         tableView.dataSource = self
         tableView.register(UINib(nibName: "PhotoTableViewCell", bundle: nil), forCellReuseIdentifier: "Cell")
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         loadData()
     }
 

--- a/iosapp/06-earthquake/View/PhotoCalloutAccessoryView.xib
+++ b/iosapp/06-earthquake/View/PhotoCalloutAccessoryView.xib
@@ -21,8 +21,10 @@
                         <constraint firstAttribute="height" constant="180" id="xpX-n4-8nz"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading.." textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GM1-m5-LjM">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GM1-m5-LjM">
                     <rect key="frame" x="0.0" y="188" width="240" height="13"/>
+                    <string key="text">
+Loading..</string>
                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                     <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>


### PR DESCRIPTION
- #78 写真のコメントが複数行の場合省略されるのを改善（完全に直すのは難しい。2行までは表示されるようにしました）
- #79 アプリを再起動しなくともマイページを毎回リロードするようにしました
- #80 タップ領域だとわかりにくいのでカメラアイコンを置いてみる

<img src=https://user-images.githubusercontent.com/893643/71987558-cc63b080-3271-11ea-9833-642de2652d4a.png  width=50%>
